### PR TITLE
Allow pinterest.com.* domains rather than just pinterest.com

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -19,7 +19,7 @@
     "tabs",
     "activeTab",
     "notifications",
-    "*://*.pinterest.com/*"
+    "*://*.pinterest.com*/*"
   ],
   "web_accessible_resources": [
     "css/fixedHeight.css",

--- a/src/js/bg.js
+++ b/src/js/bg.js
@@ -59,7 +59,7 @@ chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
 //////////////////////////////////////////////
 
 chrome.tabs.onUpdated.addListener(function(tabId, changeInfo, tab) {
-	if ((tab.url && tab.url.match("[\S]*\.pinterest\.com").length != 0 )) {
+	if ((tab.url && tab.url.match("[\S]*\.pinterest\.com[\.*]?").length != 0 )) {
 		var actived = getOption('pin_grid') == "ON";
 		var fixed = getOption('pin_grid_fixed') == "ON";
 		var height = getHeight()


### PR DESCRIPTION
Pinterest auto-routes to a local TLD so this extension doesn't activate in countries like Australia where user is redirected to pinterest.com.au
